### PR TITLE
load() is deprecated

### DIFF
--- a/demo/js/jquery.juirte.js
+++ b/demo/js/jquery.juirte.js
@@ -78,7 +78,7 @@ $.fn.juirte = function(options){
 			}
 
 			// set button status, cross browser required us to bind on load and outside of load
-			$('.'+_id+'-wysiwyg-content').load(function() {
+			$('.'+_id+'-wysiwyg-content').on("load",function() {
 				$('.'+_id+'-wysiwyg-content').contents().find("body").bind('click', function(event) {
 					fnSetButtons(event)
 				});


### PR DESCRIPTION
jquery v3 stopped juirte from working. According to https://github.com/jquery/jquery/issues/2286 .load(fn) needs to be replaced by .on("load",fn)